### PR TITLE
Install Ecspresso into toolchain cache dir

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
         version: 1.6
         force: 'true'
 
-    - uses: kayac/ecspresso@v2
+    - uses: cloudposse/ecspresso@install-into-toolchain
       with:
         version: ${{ inputs.ecspresso-version }}
 


### PR DESCRIPTION
## what
* Use cloudposse fork of ecspresso install action

## why
* The fork action install Ecspresso right way - into toolchain cache dir
