### PR TITLE
Added mirroring task definition on s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Feel free to use it as reference and starting point.
 | ecspresso-version | Ecspresso version | v2.1.0 | false |
 | image | Docker image | N/A | true |
 | image-tag | Docker image tag | N/A | true |
+| mirror\_to\_s3\_bucket | Mirror task definition to s3 bucket | N/A | false |
 | operation | Operation (valid options - `deploy`, `destroy`) | deploy | true |
 | region | AWS Region | N/A | true |
 | taskdef-path | Task definition path | N/A | true |

--- a/action.yml
+++ b/action.yml
@@ -100,10 +100,10 @@ runs:
         IMAGE: ${{ inputs.image }}:${{ inputs.image-tag }}
         AWS_REGION: ${{ inputs.region }}
 
-    - uses: shallwefootball/upload-s3-action@v1.3.3
-      name: Mirror task definition on S3
+    - name: Mirror task definition on S3
       id: s3
-      with:
-        aws_bucket: ${{ inputs.cluster }}
-        source_dir: /tmp/${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
-        destination_dir: ${{ inputs.application }}/task-definition.json
+      uses: zdurham/s3-upload-github-action@master
+      env:
+        FILE: /tmp/${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
+        S3_BUCKET: ${{ inputs.cluster }}
+        S3_KEY: ${{ inputs.application }}/task-definition.json

--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
         IMAGE: ${{ inputs.image }}:${{ inputs.image-tag }}
         AWS_REGION: ${{ inputs.region }}
 
-    - uses: shallwefootball/s3-upload-action@v1.3.3
+    - uses: shallwefootball/upload-s3-action@v1.3.3
       name: Mirror task definition on S3
       id: s3
       with:

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ inputs:
     description: Ecspresso timeout
     required: false
     default: 5m
+  mirror_to_s3_bucket:
+    description: Mirror task definition to s3 bucket
+    required: false
 
 outputs:
   webapp-url:
@@ -81,18 +84,20 @@ runs:
         AWS_REGION: ${{ inputs.region }}
 
     - name: Set random environment variables
+      if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       uses: joellefkowitz/random-env@v1.0.0
       with:
         names: |
           TMP_DIR_NAME
 
     - name: Create TMP dir
+      if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       shell: bash
       run: |
         mkdir ./${{ env.TMP_DIR_NAME }}
 
     - name: S3 mirroring
-      if: ${{ inputs.operation == 'deploy' }}
+      if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       shell: bash
       run: |
         ecspresso --config=./ecspresso.yml render task-definition > ./${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
@@ -101,14 +106,16 @@ runs:
         AWS_REGION: ${{ inputs.region }}
 
     - name: Mirror task definition on S3
+      if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       id: s3
       uses: zdurham/s3-upload-github-action@master
       env:
         FILE: ./${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
-        S3_BUCKET: ${{ inputs.cluster }}
+        S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}
         S3_KEY: ${{ inputs.application }}/task-definition.json
 
     - name: Cleanup TMP dir
+      if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       shell: bash
       run: |
         rm -rf ./${{ env.TMP_DIR_NAME }}

--- a/action.yml
+++ b/action.yml
@@ -89,13 +89,13 @@ runs:
     - name: Create TMP dir
       shell: bash
       run: |
-        mkdir /tmp/${{ env.TMP_DIR_NAME }}
+        mkdir ./${{ env.TMP_DIR_NAME }}
 
     - name: S3 mirroring
       if: ${{ inputs.operation == 'deploy' }}
       shell: bash
       run: |
-        ecspresso --config=./ecspresso.yml render task-definition > /tmp/${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
+        ecspresso --config=./ecspresso.yml render task-definition > ./${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
       env:
         IMAGE: ${{ inputs.image }}:${{ inputs.image-tag }}
         AWS_REGION: ${{ inputs.region }}
@@ -104,6 +104,11 @@ runs:
       id: s3
       uses: zdurham/s3-upload-github-action@master
       env:
-        FILE: /tmp/${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
+        FILE: ./${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
         S3_BUCKET: ${{ inputs.cluster }}
         S3_KEY: ${{ inputs.application }}/task-definition.json
+
+    - name: Cleanup TMP dir
+      shell: bash
+      run: |
+        rm -rf ./${{ env.TMP_DIR_NAME }}

--- a/action.yml
+++ b/action.yml
@@ -79,3 +79,31 @@ runs:
       env:
         IMAGE: ${{ inputs.image }}:${{ inputs.image-tag }}
         AWS_REGION: ${{ inputs.region }}
+
+    - name: Set random environment variables
+      uses: joellefkowitz/random-env@v1.0.0
+      with:
+        names: |
+          TMP_DIR_NAME
+
+    - name: Create TMP dir
+      shell: bash
+      run: |
+        mkdir /tmp/${{ env.TMP_DIR_NAME }}
+
+    - name: S3 mirroring
+      if: ${{ inputs.operation == 'deploy' }}
+      shell: bash
+      run: |
+        ecspresso --config=./ecspresso.yml render task-definition > /tmp/${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
+      env:
+        IMAGE: ${{ inputs.image }}:${{ inputs.image-tag }}
+        AWS_REGION: ${{ inputs.region }}
+
+    - uses: shallwefootball/s3-upload-action@v1.3.3
+      name: Mirror task definition on S3
+      id: s3
+      with:
+        aws_bucket: ${{ inputs.cluster }}
+        source_dir: /tmp/${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
+        destination_dir: ${{ inputs.application }}/task-definition.json

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -10,6 +10,7 @@
 | ecspresso-version | Ecspresso version | v2.1.0 | false |
 | image | Docker image | N/A | true |
 | image-tag | Docker image tag | N/A | true |
+| mirror\_to\_s3\_bucket | Mirror task definition to s3 bucket | N/A | false |
 | operation | Operation (valid options - `deploy`, `destroy`) | deploy | true |
 | region | AWS Region | N/A | true |
 | taskdef-path | Task definition path | N/A | true |


### PR DESCRIPTION
## what
* On deployment, copy `task definition` to the s3 bucket

## Why
* Mirroring to s3 is part of the disaster recovery strategy
