### PR TITLE
Change s3 mirroring path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,7 @@ runs:
       env:
         FILE: ./${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
         S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}
-        S3_KEY: ${{ inputs.application }}/task-definition.json
+        S3_KEY: ${{ inputs.cluster }}/${{ inputs.application }}/task-definition.json
 
     - name: Cleanup TMP dir
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}


### PR DESCRIPTION
## what
* Change s3 mirroring path from `${{application}}/task-definition.js` to `${{cluster_name}}/${{application}}/task-definition.js`

## why
* Allow to share one bucket for mirroring from different clusters