### PR TITLE
Encrypt task-definition on s3 mirror

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,23 +85,23 @@ runs:
 
     - name: Set random environment variables
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
-      uses: TGPSKI/name-generator-node-action@v2
-      id: generator
-      with:
-        separator: '_'
-        length: '2'
+      id: tmp
+      shell: bash
+      run: |
+        echo $RANDOM | md5sum | head -c 20
+        echo "dir_name=${VALUE}" >> $GITHUB_OUTPUT
 
     - name: Create TMP dir
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       shell: bash
       run: |
-        mkdir ./${{ steps.generator.outputs.name }}
+        mkdir ./${{ steps.tmp.outputs.dir_name }}
 
     - name: S3 mirroring
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       shell: bash
       run: |
-        ecspresso --config=./ecspresso.yml render task-definition > ./${{ steps.generator.outputs.name }}/${{ inputs.application }}.json
+        ecspresso --config=./ecspresso.yml render task-definition > ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json
       env:
         IMAGE: ${{ inputs.image }}:${{ inputs.image-tag }}
         AWS_REGION: ${{ inputs.region }}
@@ -109,9 +109,9 @@ runs:
     - name: Mirror task definition on S3
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       id: s3
-      uses: zdurham/s3-upload-github-action@1.0.1
+      uses: zdurham/s3-upload-github-action@master
       env:
-        FILE: ./${{ steps.generator.outputs.name }}/${{ inputs.application }}.json
+        FILE: ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json
         S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}
         S3_KEY: ${{ inputs.cluster }}/${{ inputs.application }}/task-definition.json
 
@@ -119,4 +119,4 @@ runs:
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       shell: bash
       run: |
-        rm -rf ./${{ steps.generator.outputs.name }}
+        rm -rf ./${{ steps.tmp.outputs.dir_name }}

--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,8 @@ runs:
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       id: s3
       uses: zdurham/s3-upload-github-action@161dfa6991b9d88a97f02f4aeb5dcd26ea7e03cd
+      with:
+        args: --server-side-encryption AES256
       env:
         FILE: ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json
         S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}

--- a/action.yml
+++ b/action.yml
@@ -108,12 +108,9 @@ runs:
 
     - name: Mirror task definition on S3
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
-      id: s3
-      uses: zdurham/s3-upload-github-action@161dfa6991b9d88a97f02f4aeb5dcd26ea7e03cd
-      env:
-        FILE: ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json
-        S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}
-        S3_KEY: ${{ inputs.cluster }}/${{ inputs.application }}/task-definition.json
+      uses: ItsKarma/aws-cli@v1.70.0
+      with:
+        args: s3 cp ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json s3://${{ inputs.mirror_to_s3_bucket }}/${{ inputs.cluster }}/${{ inputs.application }}/task-definition.json
 
     - name: Cleanup TMP dir
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}

--- a/action.yml
+++ b/action.yml
@@ -108,6 +108,12 @@ runs:
 
     - name: Mirror task definition on S3
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
+      shell: bash
+      run: |
+        aws s3 ls
+
+    - name: Mirror task definition on S3
+      if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       id: s3
       uses: zdurham/s3-upload-github-action@161dfa6991b9d88a97f02f4aeb5dcd26ea7e03cd
       env:

--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,7 @@ runs:
       id: s3
       uses: zdurham/s3-upload-github-action@161dfa6991b9d88a97f02f4aeb5dcd26ea7e03cd
       with:
-        args: "--server-side-encryption AES256"
+        args: "--sse AES256"
       env:
         FILE: ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json
         S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,7 @@ runs:
     - name: Mirror task definition on S3
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       id: s3
-      uses: zdurham/s3-upload-github-action@master
+      uses: zdurham/s3-upload-github-action@1.0.1
       env:
         FILE: ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json
         S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}

--- a/action.yml
+++ b/action.yml
@@ -85,22 +85,23 @@ runs:
 
     - name: Set random environment variables
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
-      uses: joellefkowitz/random-env@v1.2.0
+      uses: TGPSKI/name-generator-node-action@v2
+      id: generator
       with:
-        names: |
-          TMP_DIR_NAME
+        separator: '_'
+        length: '12'
 
     - name: Create TMP dir
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       shell: bash
       run: |
-        mkdir ./${{ env.TMP_DIR_NAME }}
+        mkdir ./${{ steps.generator.outputs.name }}
 
     - name: S3 mirroring
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       shell: bash
       run: |
-        ecspresso --config=./ecspresso.yml render task-definition > ./${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
+        ecspresso --config=./ecspresso.yml render task-definition > ./${{ steps.generator.outputs.name }}/${{ inputs.application }}.json
       env:
         IMAGE: ${{ inputs.image }}:${{ inputs.image-tag }}
         AWS_REGION: ${{ inputs.region }}
@@ -108,9 +109,9 @@ runs:
     - name: Mirror task definition on S3
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       id: s3
-      uses: zdurham/s3-upload-github-action@master
+      uses: zdurham/s3-upload-github-action@1.0.1
       env:
-        FILE: ./${{ env.TMP_DIR_NAME }}/${{ inputs.application }}.json
+        FILE: ./${{ steps.generator.outputs.name }}/${{ inputs.application }}.json
         S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}
         S3_KEY: ${{ inputs.cluster }}/${{ inputs.application }}/task-definition.json
 
@@ -118,4 +119,4 @@ runs:
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       shell: bash
       run: |
-        rm -rf ./${{ env.TMP_DIR_NAME }}
+        rm -rf ./${{ steps.generator.outputs.name }}

--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,7 @@ runs:
       id: s3
       uses: zdurham/s3-upload-github-action@161dfa6991b9d88a97f02f4aeb5dcd26ea7e03cd
       with:
-        args: --server-side-encryption AES256
+        args: "--server-side-encryption AES256"
       env:
         FILE: ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json
         S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
       id: generator
       with:
         separator: '_'
-        length: '12'
+        length: '2'
 
     - name: Create TMP dir
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
       id: tmp
       shell: bash
       run: |
-        echo $RANDOM | md5sum | head -c 20
+        VALUE=$(echo $RANDOM | md5sum | head -c 20)
         echo "dir_name=${VALUE}" >> $GITHUB_OUTPUT
 
     - name: Create TMP dir

--- a/action.yml
+++ b/action.yml
@@ -108,12 +108,6 @@ runs:
 
     - name: Mirror task definition on S3
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
-      shell: bash
-      run: |
-        aws sts get-caller-identity
-
-    - name: Mirror task definition on S3
-      if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       id: s3
       uses: zdurham/s3-upload-github-action@161dfa6991b9d88a97f02f4aeb5dcd26ea7e03cd
       with:

--- a/action.yml
+++ b/action.yml
@@ -108,9 +108,12 @@ runs:
 
     - name: Mirror task definition on S3
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
-      uses: ItsKarma/aws-cli@v1.70.0
-      with:
-        args: s3 cp ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json s3://${{ inputs.mirror_to_s3_bucket }}/${{ inputs.cluster }}/${{ inputs.application }}/task-definition.json
+      id: s3
+      uses: zdurham/s3-upload-github-action@161dfa6991b9d88a97f02f4aeb5dcd26ea7e03cd
+      env:
+        FILE: ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json
+        S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}
+        S3_KEY: ${{ inputs.cluster }}/${{ inputs.application }}/task-definition.json
 
     - name: Cleanup TMP dir
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ runs:
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       shell: bash
       run: |
-        aws s3 ls
+        aws sts get-caller-identity
 
     - name: Mirror task definition on S3
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,7 @@ runs:
     - name: Mirror task definition on S3
       if: ${{ inputs.operation == 'deploy' && inputs.mirror_to_s3_bucket != '' }}
       id: s3
-      uses: zdurham/s3-upload-github-action@1.0.1
+      uses: zdurham/s3-upload-github-action@161dfa6991b9d88a97f02f4aeb5dcd26ea7e03cd
       env:
         FILE: ./${{ steps.tmp.outputs.dir_name }}/${{ inputs.application }}.json
         S3_BUCKET: ${{ inputs.mirror_to_s3_bucket }}


### PR DESCRIPTION
## what
* Encrypt task-definition on S3 mirror
* Replace action that generates random dir name

## why
* Security reasons
* Old step raise errors on some GHA runners