### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/test-negative.yml
+++ b/.github/workflows/test-negative.yml
@@ -32,10 +32,10 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.2
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: us-east-2
           role-to-assume: ${{ secrets.IAM_ROLE }}
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'failure'
           actual: "${{ needs.test.outputs.result }}"

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -32,10 +32,10 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.2
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: us-east-2
           role-to-assume: ${{ secrets.IAM_ROLE }}
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `aws-actions/configure-aws-credentials@v4.0.2` → `@e6de0542...` `# v6.2.3`
  * `nick-fields/assert-action@v2` → `@0efd6166...` `# v4.0.1`

Supersedes #38
Supersedes #37
Supersedes #35
Supersedes #28

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## still on Node 20

* `1arp/create-a-file-action@0.3` (in `action.yml`) — no Node 24 release exists yet; left as-is
